### PR TITLE
FIX: Controller Subclass Progression Scrollbar

### DIFF
--- a/Mods/ImpUI_P8_Fork_26922ba9-6018-5252-075d-7ff2ba6ed879/GUI/Pages/CharacterCreation_c.xaml
+++ b/Mods/ImpUI_P8_Fork_26922ba9-6018-5252-075d-7ff2ba6ed879/GUI/Pages/CharacterCreation_c.xaml
@@ -1309,8 +1309,6 @@
 
                                                     </StackPanel>
 
-                                                    <StackPanel Width="{StaticResource gameplayPanelWidth}" HorizontalAlignment="Left">
-
                                                         <Control Template="{StaticResource featuresGainedSubHeader}" HorizontalAlignment="Left" DockPanel.Dock="Top"/>
 
                                                         <ScrollViewer Style="{StaticResource gameplayPanelScrollViewerStyle}">
@@ -1326,8 +1324,6 @@
 
                                                             </StackPanel>
                                                         </ScrollViewer>
-
-                                                    </StackPanel>
 
                                                 </DockPanel>
 


### PR DESCRIPTION
This PR removes an unnecessary Stack Panel preventing subclass progression scrollbar from displaying in Controller UI, making the subclass progression section work similarly to the class progression section

This issue is most commonly seen with the Dread Overlord subclass for Warlock, but will happen with any subclass with a sufficient amount of passives, spells, and/or selectors in their progression - the Stack Panel prevents the scrollbar from displaying and working as expected. Behavior prior to the patch is that you can continue to move down the list, but there will be no scrollbar on the screen, and your selection will be off-screen, making it hard to tell what the subclass option gives you.

# Without PR
<img width="1517" height="1079" alt="Controller Subclass Progression Scrollbar issue" src="https://github.com/user-attachments/assets/0a8410f9-153a-4633-acec-f7eb496b6bce" />

# With PR:
<img width="1229" height="991" alt="Controller Subclass Progression Scrollbar fix" src="https://github.com/user-attachments/assets/80c05292-4bf9-46d5-a193-a010f2470027" />
